### PR TITLE
[Fix] Issues on Recruitment

### DIFF
--- a/hr_cbt_portal_recruitment/data/mail_template_data.xml
+++ b/hr_cbt_portal_recruitment/data/mail_template_data.xml
@@ -13,7 +13,7 @@
                         Dear <t t-out="object.partner_id.name or 'Applicant'">Applicant</t><br/><br/>
                         You have been invited to take an assessment/test as part of your job application.
                         <div style="margin: 16px 0px 16px 0px;">
-                            <a t-att-href="(object.get_start_url())"
+                            <a t-att-href="'%s%s' % (object.get_base_url(),object.get_start_url())"
                                 style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
                                 Start Test
                             </a>
@@ -105,7 +105,9 @@
                                             Once you navigate to the link, click on start icon, and fill required / optional fields 
                                             Ensure all the forms listed here are provided:
                                             or use the link below to upload your data from the web portal
-                                            <a t-att-href="'/documentation-request/%s/' %(object.id)">Click to upload</a>
+                                            <!-- <a t-att-href="'/documentation-request/%s/' %(object.id)">Click to upload</a> -->
+                                            <a t-att-href="'%s/documentation-request/%s/' %(object.get_base_url(), object.id)">Click to upload</a>
+
                                             <br />
                                             <t t-foreach="object.applicant_documentation_checklist" t-as="file">
                                                 <li>

--- a/hr_cbt_portal_recruitment/models/hr_applicant.py
+++ b/hr_cbt_portal_recruitment/models/hr_applicant.py
@@ -167,7 +167,7 @@ class Applicant(models.Model):
                 rec.test_passed = False
 
     def get_base_url(self):
-        base_url = 	http.request.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        base_url = http.request.env['ir.config_parameter'].sudo().get_param('web.base.url')
         return base_url
 
     @api.depends("survey_panelist_input_ids")

--- a/hr_cbt_portal_recruitment/models/hr_applicant.py
+++ b/hr_cbt_portal_recruitment/models/hr_applicant.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from odoo import http
 from datetime import date, datetime
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
@@ -166,6 +166,9 @@ class Applicant(models.Model):
             else:
                 rec.test_passed = False
 
+    def get_base_url(self):
+        base_url = 	http.request.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        return base_url
 
     @api.depends("survey_panelist_input_ids")
     def compute_panel_list(self):
@@ -213,7 +216,7 @@ class Applicant(models.Model):
                     'default_no_attachment': record.mapped('applicant_documentation_checklist')\
                             .filtered(lambda data: not data.document_file)
                             })
-                template.write({
+                template.sudo().write({
                     'email_to': email_to,
                     'attachment_ids': [(6, 0, self.generate_document_checklist_attachment(record))],
                     })

--- a/hr_cbt_portal_recruitment/models/hr_recruitment_stage_inherit.py
+++ b/hr_cbt_portal_recruitment/models/hr_recruitment_stage_inherit.py
@@ -16,3 +16,5 @@ class hrRecruitmentStageInherit(models.Model):
         ],
         string='Stage Type'
     )
+
+    active = fields.Boolean(default=True)

--- a/hr_cbt_portal_recruitment/security/security_view.xml
+++ b/hr_cbt_portal_recruitment/security/security_view.xml
@@ -15,13 +15,13 @@
     <record id="group_hr_recruitment_officer_id" model="res.groups">
         <field name="name">Officer : Manage all applicants</field>
         <field name="category_id" ref="hr_cbt_portal_recruitment.module_category_human_resources_recruitment_id"/>
-        <field name="implied_ids" eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"/>
+        <field name="implied_ids" eval="[(4, ref('hr_recruitment.group_hr_recruitment_user')), (4, ref('sign.group_sign_user'))]"/>
     </record>
 
     <record id="group_hr_recruitment_admin_id" model="res.groups">
         <field name="name">Administrator</field>
         <field name="category_id" ref="hr_cbt_portal_recruitment.module_category_human_resources_recruitment_id"/>
-        <field name="implied_ids" eval="[(4, ref('hr_recruitment.group_hr_recruitment_manager'))]"/>
+        <field name="implied_ids" eval="[(4, ref('hr_recruitment.group_hr_recruitment_manager')), (4, ref('hr_cbt_portal_recruitment.group_hr_recruitment_officer_id'))]"/>
     </record>
 
     <record id="group_hr_recruitment_audit_id" model="res.groups">

--- a/hr_cbt_portal_recruitment/wizard/applicant_checklist_wizard.xml
+++ b/hr_cbt_portal_recruitment/wizard/applicant_checklist_wizard.xml
@@ -11,7 +11,7 @@
                             <field name="documentation_type_ids" required="1" widget="many2many_tags"/>
                         </group>
                         <group>
-                            <field name="sign_template_ids" required="1" widget="many2many_tags"/>
+                            <field name="sign_template_ids" required="0" widget="many2many_tags"/>
                         </group>
                         <notebook>
                             <page name="Applicants_move" string="Applicants">

--- a/hr_cbt_portal_recruitment/wizard/cbt_schedule_wizard.py
+++ b/hr_cbt_portal_recruitment/wizard/cbt_schedule_wizard.py
@@ -62,6 +62,6 @@ class CBTscheduleWizard(models.TransientModel):
             )
     
     def get_base_url(self):
-        base_url = 	http.request.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        base_url = http.request.env['ir.config_parameter'].sudo().get_param('web.base.url')
         return base_url
 

--- a/hr_cbt_portal_recruitment/wizard/cbt_schedule_wizard.py
+++ b/hr_cbt_portal_recruitment/wizard/cbt_schedule_wizard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from odoo import http
 from datetime import date, datetime
 from odoo import models, fields
 from odoo.exceptions import ValidationError
@@ -60,3 +60,8 @@ class CBTscheduleWizard(models.TransientModel):
         return self.survey_id.action_send_survey(
             self.email_invite_template, self.panelist_ids
             )
+    
+    def get_base_url(self):
+        base_url = 	http.request.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        return base_url
+


### PR DESCRIPTION
[Fix] Addressed Issues raised.

1. Add active field on hr.recruitment.stage 
2. HR recruitment/administrator must be able to see hr.jobs (Application by job positions)
3. The document to sign should be made not required
4. When the hr recruitment administrator wants to send documents, the system restrict with the following message: Due to security restrictions, you are not allowed to modify 'Email Templates' (mail.template) records. 
6. The user must have a sign / own template group
7. on mail template inside hr_cbt_portal_recruitment/data/mail_template, modify the /document-request to be dynamic